### PR TITLE
add an simple code generator CLI using AOAI

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -2243,6 +2243,30 @@ docs = ["mdx-gh-links (>=0.2)", "mkdocs (>=1.5)", "mkdocs-gen-files", "mkdocs-li
 testing = ["coverage", "pyyaml"]
 
 [[package]]
+name = "markdown-it-py"
+version = "3.0.0"
+description = "Python port of markdown-it. Markdown parsing, done right!"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "markdown-it-py-3.0.0.tar.gz", hash = "sha256:e3f60a94fa066dc52ec76661e37c851cb232d92f9886b15cb560aaada2df8feb"},
+    {file = "markdown_it_py-3.0.0-py3-none-any.whl", hash = "sha256:355216845c60bd96232cd8d8c40e8f9765cc86f46880e43a8fd22dc1a1a8cab1"},
+]
+
+[package.dependencies]
+mdurl = ">=0.1,<1.0"
+
+[package.extras]
+benchmarking = ["psutil", "pytest", "pytest-benchmark"]
+code-style = ["pre-commit (>=3.0,<4.0)"]
+compare = ["commonmark (>=0.9,<1.0)", "markdown (>=3.4,<4.0)", "mistletoe (>=1.0,<2.0)", "mistune (>=2.0,<3.0)", "panflute (>=2.3,<3.0)"]
+linkify = ["linkify-it-py (>=1,<3)"]
+plugins = ["mdit-py-plugins"]
+profiling = ["gprof2dot"]
+rtd = ["jupyter_sphinx", "mdit-py-plugins", "myst-parser", "pyyaml", "sphinx", "sphinx-copybutton", "sphinx-design", "sphinx_book_theme"]
+testing = ["coverage", "pytest", "pytest-cov", "pytest-regressions"]
+
+[[package]]
 name = "markupsafe"
 version = "2.1.3"
 description = "Safely add untrusted strings to HTML/XML markup."
@@ -2334,6 +2358,17 @@ files = [
 
 [package.dependencies]
 traitlets = "*"
+
+[[package]]
+name = "mdurl"
+version = "0.1.2"
+description = "Markdown URL utilities"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8"},
+    {file = "mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba"},
+]
 
 [[package]]
 name = "mistune"
@@ -3934,6 +3969,24 @@ files = [
 ]
 
 [[package]]
+name = "rich"
+version = "13.6.0"
+description = "Render rich text, tables, progress bars, syntax highlighting, markdown and more to the terminal"
+optional = false
+python-versions = ">=3.7.0"
+files = [
+    {file = "rich-13.6.0-py3-none-any.whl", hash = "sha256:2b38e2fe9ca72c9a00170a1a2d20c63c790d0e10ef1fe35eba76e1e7b1d7d245"},
+    {file = "rich-13.6.0.tar.gz", hash = "sha256:5c14d22737e6d5084ef4771b62d5d4363165b403455a30a1c8ca39dc7b644bef"},
+]
+
+[package.dependencies]
+markdown-it-py = ">=2.2.0"
+pygments = ">=2.13.0,<3.0.0"
+
+[package.extras]
+jupyter = ["ipywidgets (>=7.5.1,<9)"]
+
+[[package]]
 name = "rpds-py"
 version = "0.12.0"
 description = "Python bindings to Rust's persistent data structures (rpds)"
@@ -4231,6 +4284,17 @@ files = [
 docs = ["furo", "jaraco.packaging (>=9.3)", "jaraco.tidelift (>=1.4)", "pygments-github-lexers (==0.0.5)", "rst.linker (>=1.9)", "sphinx (>=3.5)", "sphinx-favicon", "sphinx-hoverxref (<2)", "sphinx-inline-tabs", "sphinx-lint", "sphinx-notfound-page (>=1,<2)", "sphinx-reredirects", "sphinxcontrib-towncrier"]
 testing = ["build[virtualenv]", "filelock (>=3.4.0)", "flake8-2020", "ini2toml[lite] (>=0.9)", "jaraco.develop (>=7.21)", "jaraco.envs (>=2.2)", "jaraco.path (>=3.2.0)", "pip (>=19.1)", "pytest (>=6)", "pytest-black (>=0.3.7)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=2.2)", "pytest-mypy (>=0.9.1)", "pytest-perf", "pytest-ruff", "pytest-timeout", "pytest-xdist", "tomli-w (>=1.0.0)", "virtualenv (>=13.0.0)", "wheel"]
 testing-integration = ["build[virtualenv] (>=1.0.3)", "filelock (>=3.4.0)", "jaraco.envs (>=2.2)", "jaraco.path (>=3.2.0)", "packaging (>=23.1)", "pytest", "pytest-enabler", "pytest-xdist", "tomli", "virtualenv (>=13.0.0)", "wheel"]
+
+[[package]]
+name = "shellingham"
+version = "1.5.4"
+description = "Tool to Detect Surrounding Shell"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "shellingham-1.5.4-py2.py3-none-any.whl", hash = "sha256:7ecfff8f2fd72616f7481040475a65b2bf8af90a56c89140852d1120324e8686"},
+    {file = "shellingham-1.5.4.tar.gz", hash = "sha256:8dbca0739d487e5bd35ab3ca4b36e11c4078f3a234bfce294b0a0291363404de"},
+]
 
 [[package]]
 name = "six"
@@ -4908,6 +4972,9 @@ files = [
 
 [package.dependencies]
 click = ">=7.1.1,<9.0.0"
+colorama = {version = ">=0.4.3,<0.5.0", optional = true, markers = "extra == \"all\""}
+rich = {version = ">=10.11.0,<14.0.0", optional = true, markers = "extra == \"all\""}
+shellingham = {version = ">=1.3.0,<2.0.0", optional = true, markers = "extra == \"all\""}
 typing-extensions = ">=3.7.4.3"
 
 [package.extras]
@@ -5636,4 +5703,4 @@ testing = ["big-O", "jaraco.functools", "jaraco.itertools", "more-itertools", "p
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.9,<3.12"
-content-hash = "1900e7b620df4e2d5f305670f9acabce36bb0944f65e2df004761e232dde53eb"
+content-hash = "835deda0afeb2dc26d87c7970f40a52eabdc52cc7d1a131c26e747c838dc89b4"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,10 @@ pytest = "^7.4.3"
 pytest-asyncio = "^0.21.1"
 httpx = "^0.25.1"
 
+
+[tool.poetry.group.scripts.dependencies]
+typer = {extras = ["all"], version = "^0.9.0"}
+
 [build-system]
 requires = ["poetry-core"]
 build-backend = "poetry.core.masonry.api"

--- a/scripts/generate_test_code.py
+++ b/scripts/generate_test_code.py
@@ -1,0 +1,52 @@
+import os
+
+import typer
+from dotenv import load_dotenv
+from langchain.agents import AgentType, initialize_agent
+from langchain.chat_models import ChatOpenAI
+from langchain_experimental.tools.python.tool import PythonREPLTool
+
+app = typer.Typer()
+
+
+@app.command()
+def run(
+    env_file: str = "./notebooks/credentials.env",
+    prompt: str = "あなたは python で書かれたプログラムコードからテストフレームワーク pytest を使ったテストコードを生成するのに役立つ Microsoft のソフトウェアエンジニアです。以下のプログラムコードに対応するテストコードを作成し、test_generated.py として保存してください。\\n```python\\n def add(a: int, b: int):\\n  return a + b```",
+):
+    """
+    To run the pipeline, you need to provide a path to the dataset and the output directory
+        > poetry run python scripts/generate_test_code.py --env-file "./notebooks/credentials.env" --prompt '"あなたは python で書かれたプログラムコードからテストフレームワーク pytest を使ったテストコードを生成するのに役立つ Microsoft のソフトウェアエンジニアです。以下のプログラムコードに対応するテストコードを作成し、test_generated.py として保存してください。\\n```python\\n def add(a: int, b: int):\\n  return a + b```"'
+    """
+    typer.echo(f"Running pipeline with {env_file}, {prompt}")
+    load_dotenv(env_file)
+
+    llm = ChatOpenAI(
+        model_name=os.getenv("OPENAI_MODEL_NAME"),
+        openai_api_base=os.getenv("OPENAI_API_BASE"),
+        openai_api_key=os.getenv("OPENAI_API_KEY"),
+        temperature=0,
+        model_kwargs={
+            "deployment_id": os.getenv("OPENAI_DEPLOYMENT_ID"),
+            "api_type": os.getenv("OPENAI_API_TYPE"),
+            "api_version": os.getenv("OPENAI_API_VERSION"),
+        },
+    )
+
+    tools = [
+        PythonREPLTool(),
+    ]
+
+    agent = initialize_agent(
+        tools=tools,
+        llm=llm,
+        agent=AgentType.CHAT_ZERO_SHOT_REACT_DESCRIPTION,
+        handle_parsing_errors=True,
+        verbose=True,
+    )
+
+    agent.run(prompt)
+
+
+if __name__ == "__main__":
+    app()


### PR DESCRIPTION
fixes #28 

For example, to generate python test code, run the following command.

```python
poetry run python scripts/generate_test_code.py \
  --env-file "./notebooks/credentials.env" \
  --prompt '"あなたは python で書かれたプログラムコードからテストフレームワーク pytest を使ったテストコードを生成するのに役立つ Microsoft のソフトウェアエンジニアです。以下のプログラムコードに対応するテストコードを作成し、test_generated.py として保存してください。\\n```python\\n def add(a: int, b: int):\\n  return a + b```"'
```
